### PR TITLE
List invoices end-point

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -61,6 +61,26 @@ class App < Base
     body pdf.read
   end
 
+  # List invoices
+  #
+  # by_account_id     - customer account identifier
+  # finalized_before  - finalized before given timestamp
+  # finalized_after   - finalized after given timestamp
+  #
+  # Returns a JSON array of {number: .., finalized_at: ..}.
+  get '/invoices' do
+    invoices = %w(by_account_id finalized_before finalized_after).reduce(
+      Invoice.finalized.newest_first
+    ) do |scope,key|
+      params.has_key?(key) ? scope.public_send(key, params[key]) : scope
+    end
+
+    json(
+      invoices.
+        map{|record| record.values.slice(:number, :finalized_at)}
+    )
+  end
+
   # Fetches a preview breakdown of the costs of a subscription.
   #
   # plan         - Stripe plan ID.

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -268,6 +268,139 @@ describe App do
     end
   end
 
+  describe 'get /invoices' do
+    let(:now) { Time.now }
+    let(:params) { {} }
+    let(:account_id) { SecureRandom.hex }
+
+    subject { get '/invoices', params }
+
+    it 'responds with OK' do
+      subject.status.must_equal 200
+    end
+
+    it 'responds with JSON' do
+      subject.content_type.must_equal 'application/json'
+    end
+
+    describe 'ordering' do
+      before do
+        (0..99).to_a.shuffle.map do |i|
+          Timecop.freeze(now + i.days) do
+            Invoice.create.finalize!
+          end
+        end
+      end
+
+      it 'lists newest first' do
+        result = JSON.parse(subject.body)
+        result.first['finalized_at'].must_be :>, result.last['finalized_at']
+      end
+    end
+
+    describe 'by account id' do
+      let(:account_invoices) do
+        10.times.map do |i|
+          Invoice.create(customer_accounting_id: account_id).finalize!
+        end
+      end
+
+      let(:other_invoices) do
+        10.times.map do |i|
+          Invoice.create.finalize!
+        end
+      end
+
+      let(:params) { {by_account_id: account_id} }
+
+      before do
+        account_invoices
+        other_invoices
+      end
+
+      it 'include all invoice for given account newest first' do
+        JSON.parse(subject.body).map do |invoice|
+          invoice["number"]
+        end.to_set.must_equal account_invoices.map(&:number).to_set
+      end
+    end
+
+    describe 'finalized before' do
+      let(:invoices) do
+        (0..9).map do |i|
+          Timecop.freeze(now + i.days) do
+            Invoice.create.finalize!
+          end
+        end
+      end
+
+      let(:params) { {finalized_before: (now + 4.days).iso8601} }
+      before { invoices }
+
+      it 'only returns the first invoices' do
+        JSON.parse(subject.body).map do |invoice|
+          invoice["number"]
+        end.to_set.must_equal invoices[0..4].map(&:number).to_set
+      end
+    end
+
+    describe 'finalized after' do
+      let(:invoices) do
+        (0..9).map do |i|
+          Timecop.freeze(now + i.days) do
+            Invoice.create.finalize!
+          end
+        end
+      end
+
+      let(:params) { {finalized_after: (now + 5.days).iso8601} }
+      before { invoices }
+
+      it 'only returns the last invoices' do
+        JSON.parse(subject.body).map do |invoice|
+          invoice["number"]
+        end.to_set.must_equal invoices[6..-1].map(&:number).to_set
+      end
+    end
+
+    describe 'combined filters' do
+      let(:account_invoices) do
+        (0..9).map do |i|
+          Timecop.freeze(now + i.days) do
+            Invoice.create(customer_accounting_id: account_id).finalize!
+          end
+        end
+      end
+
+      let(:other_invoices) do
+        (0..9).map do |i|
+          Timecop.freeze(now + i.days) do
+            Invoice.create.finalize!
+          end
+        end
+      end
+
+      let(:params) do
+        {
+          by_account_id: account_id,
+          finalized_after: (now + 5.days).iso8601,
+          finalized_before: (now + 8.days).iso8601
+        }
+      end
+
+      before do
+        account_invoices
+        other_invoices
+      end
+
+      it 'only returns the last invoices' do
+        JSON.parse(subject.body).map do |invoice|
+          invoice["number"]
+        end.to_set.must_equal account_invoices[6..-2].map(&:number).to_set
+      end
+    end
+  end
+
   describe 'get /preview' do
     it 'returns a price breakdown of a plan for a customer' do
       VCR.use_cassette('preview_success') do


### PR DESCRIPTION
Return all invoices in reverse chronological order at /invoices in the following JSON format:

```
[{"number": "2016000001", "finalized_at": "2016-01-01 00:00:00 +0100"}, ...]
```

Optionally filter with (a combination of) the follow parameters:

- `by_account_id`: customer account identifier
- `finalized_before`: finalized before given timestamp
- `finalized_after`: finalized after given timestamp