### PR TITLE
Record stripe event id on invoice

### DIFF
--- a/config/schema.rb
+++ b/config/schema.rb
@@ -1,3 +1,4 @@
+# version 0
 Configuration.db.create_table :invoices do
 
   # Ids
@@ -61,4 +62,9 @@ Configuration.db.create_table :invoices do
   String  :vies_address
   String  :vies_request_identifier
 
-end unless Configuration.db.tables.include?(:invoices)
+end unless Configuration.db.table_exists?(:invoices)
+
+# version 1
+Configuration.db.add_column(
+  :invoices, :stripe_event_id, String
+) unless Configuration.db[:invoices].columns.include?(:stripe_event_id)

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -15,6 +15,7 @@ describe App do
     Timecop.return
   end
 
+  let(:stripe_event_id) { 'xxx' }
   let(:vat_service) { mock }
 
   let(:plan) do
@@ -130,7 +131,9 @@ describe App do
         VCR.use_cassette('invoice_template_sub_no_vat_export') do
           invoice_service.create_subscription(plan: plan.id)
           invoice_service.process_payment(
-            stripe_invoice_id: customer.invoices.first.id)
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: customer.invoices.first.id
+          )
 
           invoice = Invoice.first
           complete_invoice(invoice)
@@ -151,7 +154,10 @@ describe App do
 
             id = customer.invoices.first.id
 
-            invoice_service.process_payment(stripe_invoice_id: id)
+            invoice_service.process_payment(
+              stripe_event_id: stripe_event_id,
+              stripe_invoice_id: id
+            )
 
             invoice = Invoice.last
             complete_invoice(invoice)
@@ -173,7 +179,9 @@ describe App do
         VCR.use_cassette('invoice_template_sub_no_vat_reverse') do
           invoice_service.create_subscription(plan: plan.id)
           invoice_service.process_payment(
+            stripe_event_id: stripe_event_id,
             stripe_invoice_id: customer.invoices.first.id)
+
 
           invoice = Invoice.first
           complete_invoice(invoice)
@@ -193,7 +201,9 @@ describe App do
         VCR.use_cassette('invoice_template_sub_vat') do
           invoice_service.create_subscription(plan: plan.id)
           invoice_service.process_payment(
-            stripe_invoice_id: customer.invoices.first.id)
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: customer.invoices.first.id
+          )
 
           invoice = Invoice.first
           complete_invoice(invoice)
@@ -213,7 +223,9 @@ describe App do
         VCR.use_cassette('invoice_template_sub_no_vat_discount') do
           invoice_service.create_subscription(plan: plan.id, coupon: coupon.id)
           invoice_service.process_payment(
-            stripe_invoice_id: customer.invoices.first.id)
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: customer.invoices.first.id
+          )
 
           invoice = Invoice.first
           complete_invoice(invoice)
@@ -233,7 +245,9 @@ describe App do
         VCR.use_cassette('invoice_template_sub_vat_discount') do
           invoice_service.create_subscription(plan: plan.id, coupon: coupon.id)
           invoice_service.process_payment(
-            stripe_invoice_id: customer.invoices.first.id)
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: customer.invoices.first.id
+          )
 
           invoice = Invoice.first
           complete_invoice(invoice)
@@ -254,11 +268,15 @@ describe App do
           invoice_service.create_subscription(plan: plan.id)
           stripe_invoice = customer.invoices.first
           invoice_service.process_payment(
-            stripe_invoice_id: stripe_invoice.id)
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: stripe_invoice.id
+          )
 
           Stripe::Charge.retrieve(stripe_invoice.charge).refund
           invoice_service.process_refund(
-            stripe_invoice_id: stripe_invoice.id)
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: stripe_invoice.id
+          )
 
           invoice = Invoice.last
           complete_invoice(invoice)

--- a/spec/invoice_service_spec.rb
+++ b/spec/invoice_service_spec.rb
@@ -2,6 +2,8 @@ require_relative 'spec_helper'
 
 describe InvoiceService do
 
+  let(:stripe_event_id) { 'xxx' }
+
   let(:metadata) {{
     country_code: 'NL',
     vat_registered: 'false',
@@ -55,7 +57,10 @@ describe InvoiceService do
         VCR.use_cassette('process_payment_new') do
           service.create_subscription(plan: plan.id)
 
-          invoice = service.process_payment(stripe_invoice_id: service.last_stripe_invoice.id)
+          invoice = service.process_payment(
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: service.last_stripe_invoice.id
+          )
 
           invoice.finalized?.must_equal true
           invoice.subtotal.must_equal 1499
@@ -67,6 +72,7 @@ describe InvoiceService do
           invoice.currency.must_equal 'usd'
           invoice.customer_country_code.must_equal 'NL'
           invoice.customer_vat_number.must_equal 'NL123'
+          invoice.stripe_event_id.must_equal stripe_event_id
           invoice.stripe_customer_id.must_equal customer.id
           invoice.customer_accounting_id.must_equal '10001'
           invoice.customer_vat_registered.must_equal false
@@ -95,7 +101,10 @@ describe InvoiceService do
           VCR.use_cassette('process_payment_yearly') do
             service.create_subscription(plan: plan.id)
 
-            invoice = service.process_payment(stripe_invoice_id: service.last_stripe_invoice.id)
+            invoice = service.process_payment(
+              stripe_event_id: stripe_event_id,
+              stripe_invoice_id: service.last_stripe_invoice.id
+            )
 
             invoice.finalized?.must_equal true
             invoice.interval.must_equal 'year'
@@ -109,7 +118,10 @@ describe InvoiceService do
         VCR.use_cassette('process_payment_new_discount') do
           service.create_subscription(plan: plan.id, coupon: coupon.id)
 
-          invoice = service.process_payment(stripe_invoice_id: service.last_stripe_invoice.id)
+          invoice = service.process_payment(
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: service.last_stripe_invoice.id
+          )
 
           invoice.finalized?.must_equal true
           invoice.subtotal.must_equal 1499
@@ -121,6 +133,7 @@ describe InvoiceService do
           invoice.currency.must_equal 'usd'
           invoice.customer_country_code.must_equal 'NL'
           invoice.customer_vat_number.must_equal 'NL123'
+          invoice.stripe_event_id.must_equal stripe_event_id
           invoice.stripe_customer_id.must_equal customer.id
           invoice.customer_accounting_id.must_equal '10001'
           invoice.customer_vat_registered.must_equal false
@@ -137,7 +150,10 @@ describe InvoiceService do
         VCR.use_cassette('process_payment_zero') do
           customer.subscriptions.create(plan: plan.id, trial_end: (Time.now.to_i + 1000))
           stripe_invoice = customer.invoices.first
-          invoice = service.process_payment(stripe_invoice_id: stripe_invoice.id)
+          invoice = service.process_payment(
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: stripe_invoice.id
+          )
           invoice.finalized?.must_equal false
         end
       end
@@ -147,27 +163,41 @@ describe InvoiceService do
   describe '#process_refund' do
     it 'is an orphan refund' do
       VCR.use_cassette('process_refund_orphan') do
-        proc { service.process_refund(stripe_invoice_id: 'xyz') }.must_raise InvoiceService::OrphanRefund
+        proc do
+          service.process_refund(
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: 'xyz'
+          )
+        end.must_raise InvoiceService::OrphanRefund
       end
     end
 
     describe 'when it is a real refund' do
       it 'creates a credit note' do
         VCR.use_cassette('process_refund') do
-          Stripe::InvoiceItem.create \
+          Stripe::InvoiceItem.create(
             customer: customer.id,
             amount: 100,
             currency: 'usd'
+          )
 
-        stripe_invoice = Stripe::Invoice.create(customer: customer.id)
+          stripe_invoice = Stripe::Invoice.create(customer: customer.id)
 
-        # Pay the invoice before processing the payment.
-        stripe_invoice.pay
-        service.process_payment(stripe_invoice_id: stripe_invoice.id)
+          # Pay the invoice before processing the payment.
+          stripe_invoice.pay
 
-        credit_note = service.process_refund(stripe_invoice_id: stripe_invoice.id)
-        credit_note.finalized?.must_equal true
-        credit_note.customer_accounting_id.must_equal metadata[:accounting_id]
+          service.process_payment(
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: stripe_invoice.id
+          )
+
+          credit_note = service.process_refund(
+            stripe_event_id: stripe_event_id,
+            stripe_invoice_id: stripe_invoice.id
+          )
+          credit_note.finalized?.must_equal true
+          credit_note.stripe_event_id.must_equal stripe_event_id
+          credit_note.customer_accounting_id.must_equal metadata[:accounting_id]
         end
       end
     end

--- a/spec/pdf_service_spec.rb
+++ b/spec/pdf_service_spec.rb
@@ -2,6 +2,7 @@ require_relative 'spec_helper'
 
 describe PdfService do
 
+  let(:stripe_event_id) { 'xxx' }
   let(:service) { PdfService.new }
   let(:invoice_service) { InvoiceService.new(customer_id: customer.id) }
 
@@ -32,7 +33,10 @@ describe PdfService do
     it 'generates a pdf representiation of an invoice and stores it' do
       VCR.use_cassette('pdf_generation') do
         invoice_service.create_subscription(plan: plan.id)
-        invoice_service.process_payment(stripe_invoice_id: invoice_service.last_stripe_invoice.id)
+        invoice_service.process_payment(
+          stripe_event_id: stripe_event_id,
+          stripe_invoice_id: invoice_service.last_stripe_invoice.id
+        )
 
         invoice = Invoice.first
 


### PR DESCRIPTION
The stripe event id which caused the creation of an invoices is added to the invoice record.  Note: only future invoices will have a stripe event id associated.

Closes #85.